### PR TITLE
Update extension to Manifest V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Made by [Frans Rosén](https://twitter.com/fransrosen). Presented during the ["A
 
 <img src="https://github.com/fransr/postMessage-tracker/raw/docs-images/images/listener-uber.png" width="500" />
 
-This Chrome extension monitors postMessage-listeners by showing you an indicator about the amount of listeners in the current window.
+This Chrome extension monitors postMessage-listeners by showing you an indicator about the amount of listeners in the current window. It now targets Manifest V3 so it can be loaded in modern versions of Chrome.
 
 It supports tracking listeners in all subframes of the window. It also keeps track of short-lived listeners and listeners enabled upon interactions. You can also log the listener functions and locations to look them through them at a later stage by using the Log URL-option in the extension. This enables you to find hidden listeners that are only enabled for a short time inside an iframe.
 

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -6,11 +6,11 @@ function refreshCount() {
 	txt = tab_listeners[selectedId] ? tab_listeners[selectedId].length : 0;
 	chrome.tabs.get(selectedId, function() {
 		if (!chrome.runtime.lastError) {
-			chrome.browserAction.setBadgeText({"text": ''+txt, tabId: selectedId});
-			if(txt > 0) {
-				chrome.browserAction.setBadgeBackgroundColor({ color: [255, 0, 0, 255]});
-			} else {
-				chrome.browserAction.setBadgeBackgroundColor({ color: [0, 0, 255, 0] });
+                        chrome.action.setBadgeText({"text": ''+txt, tabId: selectedId});
+                        if(txt > 0) {
+                                chrome.action.setBadgeBackgroundColor({ color: [255, 0, 0, 255]});
+                        } else {
+                                chrome.action.setBadgeBackgroundColor({ color: [0, 0, 255, 0] });
 			}
 		}
 	});
@@ -90,7 +90,7 @@ chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
 	refreshCount();
 });
 
-chrome.extension.onConnect.addListener(function(port) {
+chrome.runtime.onConnect.addListener(function(port) {
 	port.onMessage.addListener(function(msg) {
 		port.postMessage({listeners:tab_listeners});
 	});

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,12 +1,10 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "postMessage-tracker",
   "description": "Monitors and indicates postMessage-listeners in the current window.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "background": {
-    "scripts": [
-      "background.js"
-    ]
+    "service_worker": "background.js"
   },
   "content_scripts": [
     {
@@ -22,15 +20,17 @@
   ],
   "options_ui": {
     "page": "options.html",
-    "chrome_style": true
+    "open_in_tab": false
   },
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html"
   },
   "permissions": [
     "tabs",
-    "storage",
-    "http:\/\/*\/",
-    "https:\/\/*\/"
+    "storage"
+  ],
+  "host_permissions": [
+    "http://*/*",
+    "https://*/*"
   ]
 }

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -1,4 +1,4 @@
-var port = chrome.extension.connect({
+var port = chrome.runtime.connect({
 	name: "Sample Communication"
 });
 


### PR DESCRIPTION
## Summary
- upgrade manifest.json to version 3 and use service worker
- switch background badge API from `browserAction` to `action`
- replace deprecated `chrome.extension` usage
- tweak README to note manifest v3 usage

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68484c8ada28832683299233e130c346